### PR TITLE
make some deduplication earlier to reduce time spent collecting m3u8

### DIFF
--- a/src/panopto.py
+++ b/src/panopto.py
@@ -54,7 +54,7 @@ def get_video_links_in_folder(driver: webdriver, folder_id: str) -> [(str, str)]
             video_urls.append(link_url)
 
     video_playlists: [(str, str)] = []
-    for video_url in video_urls:
+    for video_url in set(video_urls):
         video_id = video_url[-36:]
         video_playlists.append(get_m3u8_playlist(driver, video_id))
 


### PR DESCRIPTION
Currently as far as I can see deduplication is only done after collecting the m3u8 links. It is more efficient to deduplicate the `video_urls` retrieved from the folder view (by doing so no video m3u8 is searched for multiple times)