### PR TITLE
Alternative searching for the m3u8 playlists for panopto

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -39,8 +39,7 @@ def filter_log(logs: list[dict], pred) -> list[str]:
         j = j["params"]
         if "request" not in j: continue
         j = j["request"]
-        if "url" not in j:
-            continue
+        if "url" not in j: continue
         url = j["url"]
         if pred(url):
             ret.append(url)

--- a/src/util.py
+++ b/src/util.py
@@ -1,3 +1,5 @@
+import json
+
 # Deduplicate a list
 # Source: https://stackoverflow.com/questions/18113835/python-list-of-tuples-deduplication
 def dedup(lst: []) -> []:
@@ -22,3 +24,24 @@ def rename_duplicates(list_of_tuples: [(str, str)]) -> [(str, str)]:
             seen[a] += 1
             list_of_tuples[i] = (list_of_tuples[i][0] + f'_{seen[a]}', b)
     return list_of_tuples
+
+# filter log of chrome for arbitrary url
+# pred: Callable[[str], bool]
+def filter_log(logs: list[dict], pred) -> list[str]:
+    ret = []
+    for l in logs:
+        if "message" not in l: continue
+        # print(l["message"], ",")
+        j = json.loads(l["message"])
+        if "message" not in j: continue
+        j = j["message"]
+        if "params" not in j: continue
+        j = j["params"]
+        if "request" not in j: continue
+        j = j["request"]
+        if "url" not in j:
+            continue
+        url = j["url"]
+        if pred(url):
+            ret.append(url)
+    return ret


### PR DESCRIPTION
Since there are some troubles with the current way we are searching for `m3u8` playlists, I implemented a new way depending on the logging of Chrome (should be somewhat comparable with the `Networks`-tab in the browser developer options).

In the current implementation I simply search for urls ending with `.m3u8` and then take the first one of the found urls (could be made interactively, but on the other side when trying to automate the downloading, interaction would be bad). Maybe if this make trouble we need to add some additional constraints to the retrieved urls.

I tested the approach only for panopto, but maybe it is applicable to TumLive as well (and can solve the problems in issue #3). `utils.py` implements generic url filtering of the retrieved log.

Because I didn't test this extensively, this PR is still WIP (not quite sure if `message->params->request->url` is the right path through the json log-object, it just works for now). Let's test it on different folders and check if there are any issues.