### PR TITLE
Fix parent process exiting before children

### DIFF
--- a/src/downloader.py
+++ b/src/downloader.py
@@ -10,8 +10,8 @@ from pathlib import Path
 def download_list_of_videos(videos: [(str, str)],
                             output_folder_path: Path, tmp_directory: Path,
                             keep_original: bool, jump_cut: bool,
-                            semaphore: Semaphore):
-    children = []
+                            semaphore: Semaphore) -> [Process]:
+    child_process_list = []
     for filename, url in videos:
         filename = re.sub('[\\\\/:*?"<>|]|[\x00-\x20]', '_', filename) + ".mp4"  # Filter illegal filename chars
         output_file_path = Path(output_folder_path, filename)
@@ -22,14 +22,14 @@ def download_list_of_videos(videos: [(str, str)],
                 or output_file_path.exists()
                 or output_file_path_jc.exists()):  # Check if file exists (we downloaded and converted it already)
             Path(output_file_path.as_posix() + ".lock").touch()  # Create lock file
-            child = Process(target=download,  # Download video in separate process
-                    args=(filename, url,
-                          output_file_path, output_file_path_jc, tmp_directory,
-                          keep_original, jump_cut,
-                          semaphore))
-            child.start()
-            children.append(child)
-    return children
+            child_process = Process(target=download,  # Download video in separate process
+                                    args=(filename, url,
+                                          output_file_path, output_file_path_jc, tmp_directory,
+                                          keep_original, jump_cut,
+                                          semaphore))
+            child_process.start()
+            child_process_list.append(child_process)
+    return child_process_list
 
 
 def download(filename: str, playlist_url: str,

--- a/src/downloader.py
+++ b/src/downloader.py
@@ -11,6 +11,7 @@ def download_list_of_videos(videos: [(str, str)],
                             output_folder_path: Path, tmp_directory: Path,
                             keep_original: bool, jump_cut: bool,
                             semaphore: Semaphore):
+    children = []
     for filename, url in videos:
         filename = re.sub('[\\\\/:*?"<>|]|[\x00-\x20]', '_', filename) + ".mp4"  # Filter illegal filename chars
         output_file_path = Path(output_folder_path, filename)
@@ -21,11 +22,14 @@ def download_list_of_videos(videos: [(str, str)],
                 or output_file_path.exists()
                 or output_file_path_jc.exists()):  # Check if file exists (we downloaded and converted it already)
             Path(output_file_path.as_posix() + ".lock").touch()  # Create lock file
-            Process(target=download,  # Download video in separate process
+            child = Process(target=download,  # Download video in separate process
                     args=(filename, url,
                           output_file_path, output_file_path_jc, tmp_directory,
                           keep_original, jump_cut,
-                          semaphore)).start()
+                          semaphore))
+            child.start()
+            children.append(child)
+    return children
 
 
 def download(filename: str, playlist_url: str,

--- a/src/main.py
+++ b/src/main.py
@@ -216,13 +216,17 @@ def main():
     # Download videos
     print("\n--------------------\n")
     print("Starting downloads:")
+    spawned_children = []
     for subject, playlists in videos_for_subject.items():
         subject_folder = Path(destination_folder_path, subject)
         subject_folder.mkdir(exist_ok=True)
-        downloader.download_list_of_videos(playlists,
+        children = downloader.download_list_of_videos(playlists,
                                            subject_folder, tmp_folder_path,
                                            keep_original, jump_cut,
                                            semaphore)
+        spawned_children = spawned_children + children
+    for child in children:
+        child.join()
 
 
 if __name__ == '__main__':

--- a/src/main.py
+++ b/src/main.py
@@ -216,17 +216,16 @@ def main():
     # Download videos
     print("\n--------------------\n")
     print("Starting downloads:")
-    spawned_children = []
+    spawned_child_processes = []
     for subject, playlists in videos_for_subject.items():
         subject_folder = Path(destination_folder_path, subject)
         subject_folder.mkdir(exist_ok=True)
-        children = downloader.download_list_of_videos(playlists,
-                                           subject_folder, tmp_folder_path,
-                                           keep_original, jump_cut,
-                                           semaphore)
-        spawned_children = spawned_children + children
-    for child in children:
-        child.join()
+        spawned_child_processes += downloader.download_list_of_videos(playlists,
+                                                                      subject_folder, tmp_folder_path,
+                                                                      keep_original, jump_cut,
+                                                                      semaphore)
+    for process in spawned_child_processes:
+        process.join()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
```shell
Traceback` (most recent call last):
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <module>
  File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/spawn.py", line 122, in spawn_main
  File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/spawn.py", line 122, in spawn_main
    exitcode = _main(fd, parent_sentinel)
    exitcode = _main(fd, parent_sentinel)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/spawn.py", line 132, in _main
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/spawn.py", line 132, in _main
    self = reduction.pickle.load(from_parent)
    self = reduction.pickle.load(from_parent)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/synchronize.py", line 115, in __setstate__
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/synchronize.py", line 115, in __setstate__
    self._semlock = _multiprocessing.SemLock._rebuild(*state)
    self._semlock = _multiprocessing.SemLock._rebuild(*state)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory
```

I had this error on macOS Monterey version 12.7.4 (Intel Architecture).
Python3 version: Python 3.12.4

Perhaps due to the Python version or my architecture, whenever the parent process exited, the children processes did not survive the exit. I assume that when the parent process exited some resources owned by it are deallocated and children cannot access them anymore, or children processes also receive the kill signal and must terminate.

**SOLUTION:** I was able to fix this by making the parent process wait on the children.