### PR TITLE
Fix Docker image build broken by webdriver-manager / adm-zip 0.5.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,25 @@
 FROM python:3-bullseye
 
-RUN apt-get update && apt-get install -y ffmpeg firefox-esr npm
+RUN apt-get update && apt-get install -y ffmpeg firefox-esr wget
 ARG TARGETARCH
 RUN if [ $TARGETARCH = "arm64" ]; then \
         apt-get install -y libavformat-dev libavdevice-dev python3-av \
     ; fi
 
-RUN npm install -g webdriver-manager
-RUN webdriver-manager update --gecko
+# webdriver-manager is unmaintained and pulls adm-zip 0.5.18, whose optional
+# chaining breaks under the Node 12 that python:3-bullseye ships. Fetch
+# geckodriver straight from Mozilla instead.
+ARG GECKODRIVER_VERSION=0.37.0
+RUN case "$TARGETARCH" in \
+        amd64) GECKO_TAR=geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz ;; \
+        arm64) GECKO_TAR=geckodriver-v${GECKODRIVER_VERSION}-linux-aarch64.tar.gz ;; \
+        *) echo "unsupported arch: $TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    wget -q -O /tmp/${GECKO_TAR} \
+        https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/${GECKO_TAR} && \
+    tar -xzf /tmp/${GECKO_TAR} -C /usr/local/bin && \
+    rm -f /tmp/${GECKO_TAR} && \
+    geckodriver --version
 
 WORKDIR /app
 
@@ -16,7 +28,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 RUN mkdir /app/output
 
-ENV NO-SANDBOX 1
+ENV NO-SANDBOX=1
 
 COPY ./src /app/src
 


### PR DESCRIPTION
## Problem

The **Docker** workflow failed on the `master` push that merged #33 (run [28942099926](https://github.com/Valentin-Metz/tum_video_scraper/actions/runs/28942099926)). The build dies at Dockerfile step 5:

```
RUN npm install -g webdriver-manager
RUN webdriver-manager update --gecko
```

```
/usr/local/lib/node_modules/webdriver-manager/node_modules/adm-zip/methods/inflater.js:1
SyntaxError: Unexpected token '.'
ERROR: failed to build: failed to solve: process "/bin/sh -c webdriver-manager update --gecko" did not complete successfully: exit code: 1
```

## Root cause

`webdriver-manager` is unmaintained and depends on `adm-zip ^0.5.2`. That range now resolves to `adm-zip@0.5.18`, published 2026-06-29, whose `methods/inflater.js` opens with:

```js
const version = +(process?.versions?.node ?? "").split(".")[0] || 0;
```

Optional chaining (`?.`) requires Node >= 14, but `python:3-bullseye` ships Node 12 via `apt`. Node 12 throws `SyntaxError: Unexpected token '.'`, so the geckodriver download aborts and the image build fails.

This is unrelated to the #33 change; it broke because `adm-zip` published a new release between the previous Docker run (2026-06-14, success) and this one (2026-07-08, failure).

## Fix

Drop `webdriver-manager` entirely and fetch the geckodriver binary directly from Mozilla's GitHub release tarball, which is the same upstream source `webdriver-manager` itself downloaded from. The `RUN` handles both `amd64` and `arm64` (via `TARGETARCH`) and fails fast on any other arch.

Also removes the now-unused `npm` apt package, and switches `ENV NO-SANDBOX 1` to the `ENV NO-SANDBOX=1` `key=value` form to clear the legacy-format warning the build was emitting.

The Docker run triggered by opening this PR is the validation: it will re-run the `docker-image.yml` workflow against the patched Dockerfile.

Fixes the regression on `master`. No behavior change to the scraper itself.